### PR TITLE
feat: add brand color options

### DIFF
--- a/demo/demo.md
+++ b/demo/demo.md
@@ -119,7 +119,10 @@ Use the `pill` property in combination with `error`, `success`, or `advisory` at
   <auro-badge space error pill>Danger</auro-badge>
   <auro-badge space success pill>Flight 167</auro-badge>
   <auro-badge space advisory pill>99</auro-badge>
-  <auro-badge space pill style="color: var(--auro-color-text-primary-on-light); background-color: var(--auro-color-brand-tropical-300); border-color: var(--auro-color-brand-tropical-300)">Flight 99</auro-badge>
+  <auro-badge space tropical-300 pill>New!</auro-badge>
+  <auro-badge space goldcoast-200 pill>394</auro-badge>
+  <auro-badge space breeze-100 pill>Flight 1</auro-badge>
+  <auro-badge space atlas-100 pill>Discount</auro-badge>
 </div>
 
 <auro-accordion lowProfile justifyRight>
@@ -130,8 +133,10 @@ Use the `pill` property in combination with `error`, `success`, or `advisory` at
   <auro-badge space error pill>Danger</auro-badge>
   <auro-badge space success pill>Flight 167</auro-badge>
   <auro-badge space advisory pill>99</auro-badge>
-
-  <auro-badge space pill style="color: var(--auro-color-text-primary-on-light); background-color: var(--auro-color-brand-tropical-300); border-color: var(--auro-color-brand-tropical-300)">Flight 99</auro-badge>
+  <auro-badge space tropical-300 pill>New!</auro-badge>
+  <auro-badge space goldcoast-200 pill>394</auro-badge>
+  <auro-badge space breeze-100 pill>Flight 1</auro-badge>
+  <auro-badge space atlas-100 pill>Discount</auro-badge>
   ```
 
 </auro-accordion>
@@ -145,7 +150,10 @@ Use the `label` property for a text label experience. The last example illustrat
   <auro-badge label error>Danger</auro-badge>
   <auro-badge label success>Success</auro-badge>
   <auro-badge label advisory>Advisory</auro-badge>
-  <auro-badge label style="color: var(--auro-color-text-primary-on-light); background-color: var(--auro-color-brand-tropical-300); border-color: var(--auro-color-brand-tropical-300)">Flight 167</auro-badge>
+  <auro-badge label tropical-300 pill>New!</auro-badge>
+  <auro-badge label goldcoast-200 pill>394</auro-badge>
+  <auro-badge label breeze-100 pill>Flight 1</auro-badge>
+  <auro-badge label atlas-100 pill>Discount</auro-badge>
 </div>
 
 <auro-accordion lowProfile justifyRight>
@@ -156,7 +164,10 @@ Use the `label` property for a text label experience. The last example illustrat
   <auro-badge label error>Danger</auro-badge>
   <auro-badge label success>Success</auro-badge>
   <auro-badge label advisory>Advisory</auro-badge>
-  <auro-badge label style="color: var(--auro-color-text-primary-on-light); background-color: var(--auro-color-brand-tropical-300); border-color: var(--auro-color-brand-tropical-300)">Flight 167</auro-badge>
+  <auro-badge label tropical-300 pill>New!</auro-badge>
+  <auro-badge label goldcoast-200 pill>394</auro-badge>
+  <auro-badge label breeze-100 pill>Flight 1</auro-badge>
+  <auro-badge label atlas-100 pill>Discount</auro-badge>
   ```
 
 </auro-accordion>

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,15 +4,19 @@ HTML custom element for the use of drawing attention to additional interface inf
 
 ## Attributes
 
-| Attribute  | Type      | Description                         |
-|------------|-----------|-------------------------------------|
-| `advisory` | `Boolean` | Enables advisory ui                 |
-| `error`    | `Boolean` | Enables error ui                    |
-| `fixed`    | `Boolean` | Uses px values instead of rem       |
-| `label`    | `Boolean` | Enables label ui option             |
-| `pill`     | `Boolean` | Enables pill ui option              |
-| `space`    | `Boolean` | Adds default spacing spec to badges |
-| `success`  | `Boolean` | Enables success ui                  |
+| Attribute       | Type      | Description                         |
+|-----------------|-----------|-------------------------------------|
+| `advisory`      | `Boolean` | Enables advisory ui                 |
+| `atlas-100`     | `Boolean` | Enables atlas ui                    |
+| `breeze-100`    | `Boolean` | Enables breeze ui                   |
+| `error`         | `Boolean` | Enables error ui                    |
+| `fixed`         | `Boolean` | Uses px values instead of rem       |
+| `goldcoast-200` | `Boolean` | Enables goldcoast ui                |
+| `label`         | `Boolean` | Enables label ui option             |
+| `pill`          | `Boolean` | Enables pill ui option              |
+| `space`         | `Boolean` | Adds default spacing spec to badges |
+| `success`       | `Boolean` | Enables success ui                  |
+| `tropical-300`  | `Boolean` | Enables tropical ui                 |
 
 ## Properties
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/auro-badge",
-  "version": "1.2.1",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/auro-badge.js
+++ b/src/auro-badge.js
@@ -20,6 +20,10 @@ import closeIcon from '@alaskaairux/icons/dist/icons/interface/x-sm_es6.js';
  * @attr {Boolean} error - Enables error ui
  * @attr {Boolean} success - Enables success ui
  * @attr {Boolean} advisory - Enables advisory ui
+ * @attr {Boolean} tropical-300 - Enables tropical ui
+ * @attr {Boolean} goldcoast-200 - Enables goldcoast ui
+ * @attr {Boolean} atlas-100 - Enables atlas ui
+ * @attr {Boolean} breeze-100 - Enables breeze ui
  * @attr {Boolean} space - Adds default spacing spec to badges
  * @attr {Boolean} pill - Enables pill ui option
  * @attr {Boolean} label - Enables label ui option

--- a/src/style.scss
+++ b/src/style.scss
@@ -217,6 +217,32 @@ $states: error, success, advisory;
   }
 }
 
+// Sass loop for various states of the badges
+$brands: tropical-300, breeze-100, atlas-100, goldcoast-200;
+
+@each $brand in $brands {
+  :host([#{$brand}]) {
+    background-color: var(--auro-color-brand-#{$brand});
+    border-color: var(--auro-color-brand-#{$brand});
+    color: var(--auro-color-text-primary-on-light);
+    @extend %hostTarget;
+  }
+
+  :host([#{$brand}]:not([disabled])) {
+    .target {
+      @media (hover: hover) {
+        &:active,
+        &:hover {
+          cursor: pointer;
+          background-color: var(--auro-color-#{$brand});
+          border-color: var(--auro-color-#{$brand});
+          filter: brightness(85%);
+        }
+      }
+    }
+  }
+}
+
 :host([label][error]),
 :host([label][success]) {
   color: var(--auro-color-base-white);


### PR DESCRIPTION
# Alaska Airlines Pull Request

Added brand color options: goldcoast-200, breeze-100, atlas-100, tropical-300

**Fixes:** #16

## Summary:

Designers have been using the color options (goldcoast-200, breeze-100, atlas-100, tropical-300) for purposes other than alerting the user. The addition of "brand colored" badges will support designers that are using badge for marketing/content.

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
