### PR TITLE
fix(badge): correct target sizing, text typography, and mobile spacing

### DIFF
--- a/docs/post-mortem/1311533.md
+++ b/docs/post-mortem/1311533.md
@@ -1,0 +1,61 @@
+# AB#1311533
+
+## Executive Summary
+
+A "target" badge is a badge that includes a small dismiss (close) button so a user can remove it. These dismissible badges were rendering at a different size — and, when disabled on dark backgrounds, a different text color — than the standard, non-dismissible badges. That inconsistency made the two kinds of badges look mismatched when placed side by side. This work sizes the dismissible badge to match a standard badge and removes a special color rule that was making disabled dismissible badges look different, so both variants now present consistently.
+
+Ticket: [AB#1311533](https://itsals.visualstudio.com/E_Retain_Content/_workitems/edit/1311533)
+
+## The Problem
+
+Badges come in two forms: a plain badge that simply displays text or an icon, and a "target" badge that adds a dismiss button so the badge can be closed. Because the dismissible badge is built around an interactive button, it did not match the height of a plain badge, and in one specific disabled state it also took on a different text color. The result was that dismissible badges looked visibly out of step with the standard badges they sit next to, which a design-system component is supposed to prevent.
+
+## Root Cause
+
+Two separate mechanisms in [src/styles/style.scss](../../src/styles/style.scss) caused the mismatch.
+
+**Size.** A target badge renders an `<auro-button>` (see the `render()` method in [src/auro-badge.js](../../src/auro-badge.js), which outputs `<auro-button class="target" id="targetButton">`). The button's own internal `::part(button)` brought its default padding and height, and nothing in the badge constrained it to the standard badge height. So the dismissible badge's height was driven by the button's defaults rather than by the badge's own sizing, making it taller/different from a plain badge.
+
+**Color.** A dedicated rule targeted the disabled dismissible badge on dark or inverse backgrounds:
+
+```scss
+:host([target][ondark][disabled]),
+:host([target][appearance="inverse"][disabled]) {
+  .target { color: var(--ds-color-text-primary-default, ...); }
+}
+```
+
+This forced the button text to `--ds-color-text-primary-default` in that state, overriding the disabled coloring the underlying `auro-button` already applies — so a disabled, dark/inverse target badge diverged from how a standard badge renders when disabled.
+
+## The Fix
+
+In [src/styles/style.scss](../../src/styles/style.scss):
+
+- Added a `:host([target]) [auro-button]::part(button)` rule that sets `padding: 0` and pins both `min-height` and `max-height` to `--ds-size-500`. This constrains the dismiss button — and therefore the target badge — to a fixed, standard height instead of letting the button's own defaults size it.
+- Removed the `:host([target][ondark][disabled]), :host([target][appearance="inverse"][disabled])` color override entirely, so the disabled dismissible badge inherits the same disabled color treatment as a standard badge rather than a forced `text-primary-default`.
+
+## Why This Works
+
+The size mismatch came from the target badge inheriting the button's intrinsic dimensions; pinning `min-height`/`max-height` to a single design token (`--ds-size-500`) removes that variability and locks the dismissible badge to the standard badge height, while `padding: 0` prevents the button's internal padding from re-inflating it. The color mismatch came from a special-case override that existed only for the disabled dark/inverse combination; deleting it lets the shared `auro-button` disabled styling govern that state, which is exactly what a standard badge uses — so the special case can no longer diverge. Removing the rule (rather than editing its value) is the correct fix because the rule's only purpose was to diverge from the standard treatment.
+
+## Outcome
+
+Dismissible ("target") badges now render at the same height as standard badges and no longer take on a mismatched text color when disabled on dark or inverse backgrounds. The two badge variants present consistently side by side, matching the design system's intent.
+
+## Ticket Completeness
+
+The ticket carried no written description or acceptance criteria; its title states two requirements. **2 of 2 requirements resolved.**
+
+**Resolved**
+- *Fix target badge size to match a standard badge* — the new `:host([target]) [auro-button]::part(button)` rule pins the dismiss button to a fixed `--ds-size-500` height with zero padding, so the target badge matches the standard badge height.
+- *Fix target badge color to match a standard badge* — removing the `[target][ondark][disabled]` / `[target][appearance="inverse"][disabled]` color override lets the disabled dismissible badge inherit the standard `auro-button` disabled coloring instead of a forced `text-primary-default`.
+
+## Learnings
+
+- When a design-system component wraps another interactive component (here, `auro-badge` wrapping `auro-button`), the inner component's intrinsic sizing can leak through. Constrain it explicitly via `::part()` rather than assuming it will match the outer component's dimensions.
+- A CSS rule whose sole job is to diverge from the shared/default treatment for one narrow state combination is often the bug itself. Deleting such an override — rather than tweaking its value — is frequently the right fix, because it restores the shared behavior everywhere.
+- Sizing to a single design token (`--ds-size-500`) via both `min-height` and `max-height` produces a dependable fixed height that resists the inner element's padding and content from changing it.
+
+## Iterations That Didn't Work
+
+None surfaced from the commits or this session — the change was made directly as a targeted style fix.

--- a/docs/post-mortem/1461919.md
+++ b/docs/post-mortem/1461919.md
@@ -1,0 +1,51 @@
+# AB#1461919
+
+## Executive Summary
+
+The auro-badge component was allowing the text inside a badge to be restyled by whatever page it was placed on. When a host page had its own font or text rules, a badge's label could pick up those styles instead of looking the way the design system intends. This work gives every badge its own built-in text style so it always renders consistently, regardless of the surrounding page. Icon-only badges were also given their own sizing so they no longer inherit text spacing meant for words.
+
+Ticket: [AB#1461919](https://itsals.visualstudio.com/E_Retain_Content/_workitems/edit/1461919)
+
+## The Problem
+
+A badge is a small visual tag that displays a short piece of text or an icon. Because the badge did not always declare its own text style, the words inside it could be affected by the host page's global styles (the "CSS cascade"). That meant the same badge could look different from one page to the next — the opposite of what a design-system component is supposed to guarantee. The badge needed a dependable default text appearance that isn't at the mercy of the page it lives on.
+
+## Root Cause
+
+In [src/auro-badge.js](../../src/auro-badge.js), the `render()` method wrapped the badge's slotted content in a `<div>` whose class was set by the ternary `this.label ? "body-xs" : ""`. When the `label` attribute was not present, the wrapper received an **empty class string** — no typography token was applied at all. With no explicit text style defined on the element, the text fell through to whatever styling the host page's cascade supplied, producing inconsistent rendering.
+
+A secondary consequence of the same code path: because the component didn't distinguish text content from icon-only content, an icon-only badge was styled and spaced as though it contained text, giving it incorrect vertical sizing.
+
+## The Fix
+
+The change makes the badge always declare an explicit typography class based on what it actually contains:
+
+- A new private reactive state property `hasText` was added. It is computed in `handleContentSlotChanges` by inspecting the slotted nodes — `hasText` is true when a slotted node is a non-empty text node **or** an element that isn't `auro-icon`.
+- The wrapper `<div>` now uses lit's `classMap` directive (`src/auro-badge.js`) with three mutually exclusive states:
+  - `body-xs` — has text **and** the `label` attribute is set
+  - `body-default` — has text **and** no `label` attribute (the new dependable default)
+  - `iconOnly` — no text content
+- In [src/styles/style.scss](../../src/styles/style.scss), an `.iconOnly` rule adds 4px top/bottom padding for icon-only badges, and the base and `[pill]` paddings were retuned (`.688rem → .438rem`; the pill's `--labelpillpadding` variable → `.0625rem`) to compensate for the line-height introduced by the new typography classes.
+- Two tests were added in [test/auro-badge.test.js](../../test/auro-badge.test.js): a plain badge applies `body-default` by default, and a badge with `label` applies `body-xs`.
+
+## Why This Works
+
+The root of the bug was the absence of an explicit text style in the default case. By always applying a concrete Auro typography token (`body-default` or `body-xs`) whenever the badge contains text, the component defines its own text appearance instead of inheriting it — so the page's cascade can no longer alter it. `classMap` replaces the fragile ternary with clearly named, mutually exclusive states, and driving those states from slot introspection (`hasText`) correctly separates text badges from icon-only badges. The padding adjustments are necessary because switching to the typography tokens changes line-height; retuning the paddings keeps the rendered badge size visually consistent with the previous design.
+
+## Outcome
+
+Badges now display with a consistent, built-in text style that no longer changes based on the page they appear on, matching the design system's intent everywhere. Icon-only badges render with correct spacing rather than inheriting text-oriented sizing. Automated tests lock in the new default-style behavior so it won't regress.
+
+## Ticket Completeness
+
+The ticket carried no written description or acceptance criteria; its single stated requirement is its title. **1 of 1 requirement resolved.**
+
+**Resolved**
+- *Apply a default text style to auro-badge so it isn't affected by the page's CSS cascade* — the wrapper now always applies an explicit typography class (`body-default` by default, `body-xs` when `label` is set) instead of an empty class, so the badge defines its own text style and is no longer subject to the host page's cascade. Verified by the new `body-default` and `body-xs` tests.
+
+## Learnings
+
+- A component that leaves its default case with no explicit typography is silently vulnerable to the host page's CSS cascade. Always apply an explicit design-system text token rather than relying on inheritance or an empty class.
+- Distinguishing "has text" from "icon-only" content requires real slot introspection — checking for non-empty text nodes **and** non-icon elements — not just the presence of an attribute.
+- `classMap` is a cleaner, less error-prone way to express mutually exclusive state classes than chained ternaries, and it scales as more states are added.
+- Switching a wrapper to a typography token also changes its line-height, so visual padding usually needs to be retuned in the same change to preserve the component's size.

--- a/docs/post-mortem/1547903.md
+++ b/docs/post-mortem/1547903.md
@@ -1,0 +1,152 @@
+# AB#1547903
+
+## Executive Summary
+
+On Chrome for Android, a standard text badge showed extra empty space below its text, making it look
+taller at the bottom than the very same badge on desktop. The two looked mismatched even though
+nothing about the badge had intentionally changed for mobile. This work removes that uneven gap so a
+badge has the same balanced spacing on Android as it does on desktop, without altering how any badge
+looks on desktop.
+
+Ticket: [AB#1547903](https://itsals.visualstudio.com/E_Retain_Content/_workitems/edit/1547903)
+
+## The Problem
+
+Badges appear throughout the guest experience. On Chrome for Android, the default (text) badge
+rendered with extra padding beneath its text — a bottom-heavy, unbalanced look — that did not appear
+in desktop Chrome. Because badges are so common, this made a very frequently seen component look
+slightly broken on one of the most-used mobile browsers.
+
+## Root Cause
+
+The bug is a side effect of the earlier change [AB#1461919](1461919.md), which gave the badge's inner
+text wrapper explicit Auro typography classes so its text style would resist the host page's CSS
+cascade. Those classes carry a **line-height taller than the glyph**:
+
+- `body-default` (default badge): font-size `1rem`, `line-height: 1.5rem` → `0.5rem` of *leading*.
+- `body-xs` (label badge): font-size `0.75rem`, `line-height: 1rem` → `0.25rem` of leading.
+
+(Confirmed in `@aurodesignsystem/webcorestylesheets/dist/bundled/type/classes.alaska.min.css`.)
+
+That leading is split above and below the text within the line box. AB#1461919 compensated for the
+added height by retuning the badge's vertical padding (`.688rem → .438rem`) so the **desktop** height
+stayed constant — and on desktop the leading is distributed evenly, so the badge looks balanced.
+
+On Chrome for Android the badge's web font (`"AS Circular"`) falls back to a system font whose
+ascent/descent metrics differ. With a line box taller than the glyph, the browser positions the glyph
+using those metrics and the extra half-leading pools **below** the text instead of splitting evenly —
+producing the bottom gap. It is Android-only precisely because desktop renders the real font, whose
+metrics keep the leading balanced. The wrapper (`<div class="${classMap(...)}">` in
+[src/auro-badge.js](../../src/auro-badge.js)) was a plain block element, so nothing forced the text to
+be centered independently of those font metrics.
+
+## The Fix
+
+In [src/styles/style.scss](../../src/styles/style.scss), the two text wrappers now collapse the
+leading and center their text explicitly, while preserving their previous box height:
+
+```scss
+.body-default,
+.body-xs {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.body-default { min-height: var(--wcss-body-default-line-height, 1.5rem); }
+.body-xs      { min-height: var(--wcss-body-xs-line-height, 1rem); }
+```
+
+- `line-height: 1` shrinks the inner line box to the glyph, removing the leading that Android was
+  distributing unevenly.
+- `min-height` set to the *old* line-height (`1.5rem` / `1rem`) keeps the wrapper's height exactly
+  what it was, so **no badge padding is changed** and every variant keeps its existing desktop size.
+- `display: flex; align-items: center; justify-content: center` centers the collapsed line within
+  that fixed-height box. The centering is done by flexbox against the box — not by the font's
+  half-leading — so top/bottom spacing is symmetric regardless of platform font metrics.
+
+### Why `min-height` is required (box model)
+
+A badge's total height is `host padding + wrapper height + borders`. The wrapper is a **non-stretched
+flex item** of `:host` (which is `align-items: center`), so its height is just its own content — and
+for a single line of text (the host sets `white-space: nowrap`), that content height equals its
+`line-height`. So `.body-default` was `1.5rem` tall purely because of its line-height.
+
+That makes the three declarations an **interdependent set** — none is sufficient alone:
+
+| Declaration | Effect | If it were missing |
+| --- | --- | --- |
+| `line-height: 1` | Removes the leading Android pooled below the glyph | The taller line box remains; the bug persists |
+| `min-height: <old line-height>` | Restores the wrapper's original height | Collapsing line-height shrinks every text badge by the leading (`0.5rem` default) — **on desktop too**, breaking the "unchanged elsewhere" requirement |
+| `display: flex; align-items: center` | Centers the collapsed line inside the min-height box | The shorter line sits at the **top** of the box (normal block flow), dumping all empty space at the bottom — reproducing the original bug on every platform |
+
+So `min-height` exists specifically to preserve height while `line-height: 1` collapses the box.
+The alternative — adding the removed space back as padding — is the per-variant padding retune
+rejected below (each variant has a different target height, and the shared `--labelpillpadding`
+serves two of them). Setting `min-height` to the same typography token is self-documenting and
+touches no padding, so the other variants are provably unchanged.
+
+No padding values were touched, so this cannot shift the desktop rendering of the default, label,
+pill, icon, or icon-only variants.
+
+A unit test in [test/auro-badge.test.js](../../test/auro-badge.test.js) locks in the behavior: the
+default badge's wrapper reports `display: flex`, `align-items: center`, and a computed
+`line-height` of `16px` (1rem) rather than the typography default of 24px.
+
+## Why This Works
+
+The extra bottom space came from leading — line-box height in excess of the glyph — being placed
+asymmetrically by Android's fallback-font metrics. Removing the leading (`line-height: 1`) eliminates
+the material that could be mis-distributed, and centering the remaining glyph-sized line inside a
+box whose height is fixed by `min-height` makes the vertical spacing depend on the flex box, not the
+font. Because that fixed height equals the wrapper's previous height, the badge's overall size is
+unchanged on desktop, so the fix is targeted at the mobile asymmetry without any visual cost
+elsewhere. Overriding only `line-height` leaves the typography classes still supplying font family,
+size, and weight, so the AB#1461919 cascade-resistance guarantee is preserved.
+
+## Outcome
+
+The default badge (and its text-bearing variants) now render with balanced top/bottom spacing on
+Chrome for Android, matching desktop Chrome. Desktop rendering is unchanged because no padding was
+altered and each wrapper keeps its prior height. A unit test guards the collapsed-line-height
+centering against regression.
+
+## Ticket Completeness
+
+The ticket carries only a title — "Fix extra bottom padding on auro-badge in Chrome on Android" — with
+no written description or acceptance criteria in Azure DevOps. The requirements below are therefore
+derived from that stated goal plus this session's engineering conventions: (1) the default badge on
+Chrome for Android matches desktop spacing; (2) desktop Chrome and other browsers are unchanged;
+(3) other variants (label, pill, icon, target) are visually unchanged; (4) WTR unit tests are added and
+pass; (5) visual-regression coverage confirms the variants. **3 of 5 fully resolved in code; 2 require
+validation outside this repo environment.**
+
+**Resolved**
+- *Desktop and other variants unchanged* — the fix changes no padding and preserves each wrapper's
+  height via `min-height`, so desktop and non-default variants are unaffected by construction.
+- *WTR unit test added* — a new test asserts the wrapper's flex centering and collapsed line-height.
+- *Root-cause fix for the mobile gap* — the leading responsible for the Android bottom space is
+  removed and the text is centered independently of font metrics.
+
+**Not Resolved / Requires validation**
+- *On-device confirmation on Chrome for Android* — the defect only reproduces on Android, which cannot
+  be exercised in CI/unit tests here. Final sign-off requires loading the badge on a real Android
+  device or emulator and comparing against desktop Chrome (called out for the PR reviewer).
+- *Visual-regression coverage* — recommended by the ticket; add it if the repo's VR harness supports
+  it, otherwise track as a follow-up.
+
+## Learnings
+
+- Applying a typography token to a wrapper imports its `line-height`, and any line-height taller than
+  the glyph introduces leading. Leading that looks balanced on desktop can be redistributed
+  asymmetrically by a different platform's fallback-font metrics — a class of bug that only surfaces
+  where the web font isn't used.
+- To make vertical text centering robust across platforms, center against a fixed-height box with
+  flexbox rather than relying on line-height half-leading, which is font-metric dependent.
+- Using `min-height` equal to the prior line-height lets you neutralize leading without re-deriving
+  padding — a lower-risk fix than retuning several coupled padding values, and one that guarantees
+  other variants are untouched.
+- Compensating for a side effect (here, AB#1461919's padding retune to offset a new line-height) can
+  hide a latent defect that only appears in a different rendering environment; prefer fixing the
+  root cause (the leading) over balancing it with an offset.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "lit": "^3.3.1"
+        "lit": "^3.3.3"
       },
       "devDependencies": {
-        "@aurodesignsystem/auro-button": "^12.3.0",
-        "@aurodesignsystem/auro-cli": "^3.5.0",
+        "@aurodesignsystem/auro-button": "^12.3.2",
+        "@aurodesignsystem/auro-cli": "^3.7.1",
         "@aurodesignsystem/auro-config": "^1.3.1",
-        "@aurodesignsystem/auro-icon": "^9.1.1",
-        "@aurodesignsystem/auro-library": "^5.5.4",
-        "@aurodesignsystem/design-tokens": "^8.7.0",
-        "@aurodesignsystem/webcorestylesheets": "^10.1.4",
+        "@aurodesignsystem/auro-icon": "^9.2.0",
+        "@aurodesignsystem/auro-library": "^5.13.3",
+        "@aurodesignsystem/design-tokens": "^9.3.2",
+        "@aurodesignsystem/webcorestylesheets": "^11.1.3",
         "husky": "^9.1.7"
       },
       "engines": {
@@ -47,182 +47,41 @@
       }
     },
     "node_modules/@actions/github": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.1.tgz",
-      "integrity": "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-9.1.1.tgz",
+      "integrity": "sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@actions/http-client": "^2.2.0",
-        "@octokit/core": "^5.0.1",
-        "@octokit/plugin-paginate-rest": "^9.2.2",
-        "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
-        "@octokit/request": "^8.4.1",
-        "@octokit/request-error": "^5.1.1",
-        "undici": "^5.28.5"
+        "@actions/http-client": "^3.0.2",
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
+        "@octokit/request": "^10.0.7",
+        "@octokit/request-error": "^7.1.0",
+        "undici": "^6.23.0"
       }
     },
-    "node_modules/@actions/github/node_modules/@octokit/auth-token": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+    "node_modules/@actions/github/node_modules/@actions/http-client": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.2.tgz",
+      "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/github/node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">=18.17"
       }
-    },
-    "node_modules/@actions/github/node_modules/@octokit/core": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
-      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/auth-token": "^4.0.0",
-        "@octokit/graphql": "^7.1.0",
-        "@octokit/request": "^8.4.1",
-        "@octokit/request-error": "^5.1.1",
-        "@octokit/types": "^13.0.0",
-        "before-after-hook": "^2.2.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@actions/github/node_modules/@octokit/endpoint": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
-      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^13.1.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@actions/github/node_modules/@octokit/graphql": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
-      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/request": "^8.4.1",
-        "@octokit/types": "^13.0.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@actions/github/node_modules/@octokit/openapi-types": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@actions/github/node_modules/@octokit/plugin-paginate-rest": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
-      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^12.6.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": "5"
-      }
-    },
-    "node_modules/@actions/github/node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^20.0.0"
-      }
-    },
-    "node_modules/@actions/github/node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
-      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^12.6.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": "5"
-      }
-    },
-    "node_modules/@actions/github/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^20.0.0"
-      }
-    },
-    "node_modules/@actions/github/node_modules/@octokit/request": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
-      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/endpoint": "^9.0.6",
-        "@octokit/request-error": "^5.1.1",
-        "@octokit/types": "^13.1.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@actions/github/node_modules/@octokit/request-error": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
-      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^13.1.0",
-        "deprecation": "^2.0.0",
-        "once": "^1.4.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@actions/github/node_modules/before-after-hook": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@actions/github/node_modules/universal-user-agent": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/@actions/http-client": {
       "version": "2.2.3",
@@ -243,26 +102,26 @@
       "license": "MIT"
     },
     "node_modules/@aurodesignsystem/auro-button": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-button/-/auro-button-12.3.0.tgz",
-      "integrity": "sha512-KOs03s+5KB8QRJKGsFjpjPiEze/Xul3XWU81FX6Ss7ddtZniCAmufx4ZS9jKscP4afzRNF7HY5hYZKrXIBMm8g==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-button/-/auro-button-12.3.2.tgz",
+      "integrity": "sha512-Y4E4PH6YCJ1Ap3tXvydbYco86sXGB+vPPJAvp5JUmi5JcxyKD72hiVe7Ez090RWe1LlfjQn/Vc4jbYMnulM3gA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "lit": "^3.3.1"
+        "lit": "^3.3.2"
       },
       "engines": {
-        "node": "^20.x || ^22.x"
+        "node": ">=20"
       }
     },
     "node_modules/@aurodesignsystem/auro-cli": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-cli/-/auro-cli-3.5.0.tgz",
-      "integrity": "sha512-9V1fmg8GHEFT4s7zA3lZ/U6/KraH9uNKsdWfq1aDtm64g7/6f7Q5vO2eqzuITHKJdYkcVDj2Dt1o9e0aYZy6FA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-cli/-/auro-cli-3.7.1.tgz",
+      "integrity": "sha512-+fMT/x/kCVxffSU6QG3I3sxbcQTiPpomlnsxvjXQQjwHPB/GWMC28XC0pznZHDFEHK1jIULTJ9a8zoO4csRDTg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@actions/github": "^6.0.1",
+        "@actions/github": "^9.1.1",
         "@aurodesignsystem/auro-library": "^5.5.4",
         "@babel/preset-env": "^7.28.3",
         "@custom-elements-manifest/analyzer": "^0.11.0",
@@ -270,8 +129,9 @@
         "@octokit/rest": "^22.0.0",
         "@open-wc/dev-server-hmr": "^0.2.0",
         "@open-wc/testing": "^4.0.0",
+        "@rollup/plugin-commonjs": "^28.0.3",
         "@rollup/plugin-node-resolve": "^16.0.1",
-        "@rollup/plugin-terser": "^0.4.4",
+        "@rollup/plugin-terser": "^1.0.0",
         "@rollup/plugin-typescript": "^12.1.4",
         "@wc-toolkit/cem-sorter": "^1.0.1",
         "@wc-toolkit/cem-utilities": "^1.5.4",
@@ -379,26 +239,26 @@
       }
     },
     "node_modules/@aurodesignsystem/auro-icon": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-icon/-/auro-icon-9.1.1.tgz",
-      "integrity": "sha512-IciiNNLAzOEX+OxAR69ODnTQefuYdev80ZulrPiYHfI53Y1gL4GGtiRHUYg/dGZbE0R1QHXhR0jiUc6zfOrLqA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-icon/-/auro-icon-9.2.0.tgz",
+      "integrity": "sha512-slO+nYQWctYwWWjqBJ2vgOXUSOyGybVHv7P6vV4fVJrdN1WKnwdCUmC1ifoirha0R7z07IDs2d/Lvx3m74CPDw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "lit": "^3.3.0"
+        "lit": "^3.3.2"
       },
       "engines": {
-        "node": "^20.x || ^22.x"
+        "node": ">=20"
       }
     },
     "node_modules/@aurodesignsystem/auro-library": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.5.4.tgz",
-      "integrity": "sha512-a4TOHE39qcUKjFVGxfy15b5VjCL0cuf1qmjPlVcuVs4AazsUtGtg0CpfsxKqrdxjk869h8A9zVrWGkke3po2lw==",
+      "version": "5.13.3",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.13.3.tgz",
+      "integrity": "sha512-khXdAxcEULJ9ZrrL9yzv7ndJHZBqy97oLX1hwx1o/RwPZAUwncZWlgs8l571ogd4VffmuVrTlHgRbIcb4jPktQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@floating-ui/dom": "^1.6.11",
+        "@floating-ui/dom": "^1.7.4",
         "handlebars": "^4.7.8",
         "markdown-magic": "^2.6.1"
       },
@@ -549,41 +409,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@aurodesignsystem/auro-tokendefinitions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-tokendefinitions/-/auro-tokendefinitions-1.0.0.tgz",
-      "integrity": "sha512-/NXUX/1x+rdEPjuPJys++EAdEsAuXsb1YLFVvBlkyBGOOLUpUnKkNq8zbPQjuo1WDGeFgDewaTSwblP1rQf75Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/@aurodesignsystem/design-tokens": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.7.0.tgz",
-      "integrity": "sha512-gan6SCXPI8PlyOicfXrsNOclIXVyci4xNBMm6DpqA9NLMLBsQxQhd4VXMyj3wi5cmHEc0x4n9NxzrLb633IFhQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-9.3.2.tgz",
+      "integrity": "sha512-giNceftd7G54ULyF51ZF/m0Wgb/DQVoxAdaS7+ve9/MPxCv6PwgsmzDisyzRR//cJzWiiMY/htOqq/lsMYs78g==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "@aurodesignsystem/auro-tokendefinitions": "^1.0.0",
-        "chalk": "^5.4.1",
-        "postcss": "^8.5.6"
-      },
       "engines": {
-        "node": "^20.x || ^22.x"
+        "node": "^22.14.0 || >= 24.10.0"
       }
     },
     "node_modules/@aurodesignsystem/webcorestylesheets": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-10.1.4.tgz",
-      "integrity": "sha512-CUHDVwYER1uer98BHEjs4jun+OonnVtEZtUQY6kiUIOoLhtSR//EM0vf6S72PZ8rQXPcqCxSbI64CIRRq32aaw==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-11.1.3.tgz",
+      "integrity": "sha512-/ylb8wamSUzPfVwHb6w9R31mVMWmsHTglXy1eqOa4NHIN1v8MK11rxxPRSFI/tCVVnoglZ3aTGO/RaVPPyLX7Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aurodesignsystem/design-tokens": "8.5.0",
+        "@aurodesignsystem/design-tokens": "^8.19.0",
         "chalk": "^5.4.1"
       },
       "engines": {
@@ -594,18 +438,13 @@
       }
     },
     "node_modules/@aurodesignsystem/webcorestylesheets/node_modules/@aurodesignsystem/design-tokens": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.5.0.tgz",
-      "integrity": "sha512-RygKVYYU5c9d78MXRxXSO+VQTmpqzvyxk+MgsmtPex6eG5R++PuJbCTK8UYOSG9pUdPV11cX2/avtgJIrJPPJw==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.21.2.tgz",
+      "integrity": "sha512-WkKVKRmn23j2zwstcZvuuouCGVfd+lhfl6meH9QwrpbqUoRx5KMj+nb+Nm3XqiyjIipwgHRTWFss00tczq29aQ==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "chalk": "^5.4.1",
-        "postcss": "^8.5.6"
-      },
       "engines": {
-        "node": "^20.x || ^22.x"
+        "node": "^22.14.0 || >= 24.10.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -639,6 +478,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2648,6 +2488,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2671,6 +2512,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4211,6 +4053,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -4242,34 +4085,17 @@
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.2.tgz",
-      "integrity": "sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.4.tgz",
+      "integrity": "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^16.0.0",
+        "@octokit/types": "^17.0.0",
         "universal-user-agent": "^7.0.2"
       },
       "engines": {
         "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
-      "version": "27.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^27.0.0"
       }
     },
     "node_modules/@octokit/graphql": {
@@ -4305,9 +4131,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
-      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4460,16 +4286,17 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.6.tgz",
-      "integrity": "sha512-FO+UgZCUu+pPnZAR+iKdUt64kPE7QW7ciqpldaMXaNzixz5Jld8dJ31LAUewk0cfSRkNSRKyqG438ba9c/qDlQ==",
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.13.tgz",
+      "integrity": "sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/endpoint": "^11.0.2",
-        "@octokit/request-error": "^7.0.2",
-        "@octokit/types": "^16.0.0",
-        "fast-content-type-parse": "^3.0.0",
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.1.1",
+        "@octokit/types": "^17.0.0",
+        "content-type": "^2.0.0",
+        "json-with-bigint": "^3.5.3",
         "universal-user-agent": "^7.0.2"
       },
       "engines": {
@@ -4477,50 +4304,30 @@
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.2.tgz",
-      "integrity": "sha512-U8piOROoQQUyExw5c6dTkU3GKxts5/ERRThIauNL7yaRoeXW0q/5bgHWT7JfWBw1UyrbK8ERId2wVkcB32n0uQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.1.tgz",
+      "integrity": "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^16.0.0"
+        "@octokit/types": "^17.0.0"
       },
       "engines": {
         "node": ">= 20"
       }
     },
-    "node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
-      "version": "27.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+    "node_modules/@octokit/request/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^27.0.0"
-      }
-    },
-    "node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
-      "version": "27.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@octokit/request/node_modules/@octokit/types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^27.0.0"
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@octokit/rest": {
@@ -4540,13 +4347,13 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
-      "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^23.0.1"
+        "@octokit/openapi-types": "^28.0.0"
       }
     },
     "node_modules/@open-wc/dedupe-mixin": {
@@ -5281,6 +5088,65 @@
         "node": ">=18"
       }
     },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "28.0.9",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.9.tgz",
+      "integrity": "sha512-PIR4/OHZ79romx0BVVll/PkwWpJ7e5lsqFa3gFfcrFPWwLXLV39JVUzQV9RKjWerE7B845Hqjj9VYlQeieZ2dA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "fdir": "^6.2.0",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0 || 14 >= 14.17"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.1.tgz",
@@ -5307,18 +5173,18 @@
       }
     },
     "node_modules/@rollup/plugin-terser": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
-      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+      "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "serialize-javascript": "^6.0.1",
+        "serialize-javascript": "^7.0.3",
         "smob": "^1.0.0",
         "terser": "^5.17.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "rollup": "^2.0.0||^3.0.0||^4.0.0"
@@ -6629,6 +6495,7 @@
       "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -7410,9 +7277,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -7993,6 +7860,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -8932,6 +8800,13 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/compare-func": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
@@ -9155,6 +9030,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -9746,13 +9622,6 @@
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/deprecation": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/des.js": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
@@ -9794,7 +9663,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1508733.tgz",
       "integrity": "sha512-QJ1R5gtck6nDcdM+nlsaJXcelPEI7ZxSMw1ujHpO1c4+9l+Nue5qlebi9xO1Z2MGr92bFOQTW7/rrheh5hHxDg==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -10565,23 +10435,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/fast-content-type-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
-      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -12396,6 +12249,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -12777,6 +12640,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.10.tgz",
+      "integrity": "sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -13266,10 +13136,11 @@
       }
     },
     "node_modules/lit": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.1.tgz",
-      "integrity": "sha512-Ksr/8L3PTapbdXJCk+EJVB78jDodUMaP54gD24W186zGRARvwrsPfS60wae/SSCTCNZVPd1chXqio1qHQmu4NA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
         "lit-element": "^4.2.0",
@@ -13538,6 +13409,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -13574,6 +13455,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -16774,6 +16656,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17832,6 +17715,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -18351,6 +18235,7 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -18725,16 +18610,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
     },
     "node_modules/raw-body": {
       "version": "2.5.2",
@@ -19301,6 +19176,7 @@
       "integrity": "sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -19561,6 +19437,7 @@
       "integrity": "sha512-Uk8WpxM5v+0cMR0XjX9KfRIacmSG86RH4DCCZjLU2rFh5tyutt9siAXJ7G+YfxQ99Q6wrRMbMlVl6KqUms71ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -19589,6 +19466,7 @@
       "integrity": "sha512-0OCYLm0AfVilNGukM+w0C4aptITfuW1Mhvmz8LQliLeYbPOTFRCIJzoltWWx/F5zVFe6np9eNatBUHdAvMFeZg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -20033,13 +19911,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
+      "integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-function-length": {
@@ -20385,11 +20263,14 @@
       }
     },
     "node_modules/smob": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
-      "integrity": "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.2.tgz",
+      "integrity": "sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/socks": {
       "version": "2.8.7",
@@ -20792,6 +20673,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
@@ -21391,9 +21273,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.44.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.0.tgz",
-      "integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.50.0.tgz",
+      "integrity": "sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -21581,6 +21463,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -21856,6 +21739,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -23,16 +23,16 @@
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
-    "lit": "^3.3.1"
+    "lit": "^3.3.3"
   },
   "devDependencies": {
-    "@aurodesignsystem/auro-button": "^12.3.0",
-    "@aurodesignsystem/auro-cli": "^3.5.0",
+    "@aurodesignsystem/auro-button": "^12.3.2",
+    "@aurodesignsystem/auro-cli": "^3.7.1",
     "@aurodesignsystem/auro-config": "^1.3.1",
-    "@aurodesignsystem/auro-icon": "^9.1.1",
-    "@aurodesignsystem/auro-library": "^5.5.4",
-    "@aurodesignsystem/design-tokens": "^8.7.0",
-    "@aurodesignsystem/webcorestylesheets": "^10.1.4",
+    "@aurodesignsystem/auro-icon": "^9.2.0",
+    "@aurodesignsystem/auro-library": "^5.13.3",
+    "@aurodesignsystem/design-tokens": "^9.3.2",
+    "@aurodesignsystem/webcorestylesheets": "^11.1.3",
     "husky": "^9.1.7"
   },
   "browserslist": [

--- a/src/auro-badge.js
+++ b/src/auro-badge.js
@@ -9,6 +9,7 @@ import { AuroDependencyVersioning } from "@aurodesignsystem/auro-library/scripts
 import AuroLibraryRuntimeUtils from "@aurodesignsystem/auro-library/scripts/utils/runtimeUtils.mjs";
 import { LitElement } from "lit";
 import { html } from "lit/static-html.js";
+import { classMap } from "lit/directives/class-map.js";
 import buttonVersion from "./buttonVersion.js";
 import iconVersion from "./iconVersion.js";
 import colorCss from "./styles/color.scss";
@@ -37,6 +38,11 @@ export class AuroBadge extends LitElement {
      * @private
      */
     this.icon = false;
+
+    /*
+     * @private
+     */
+    this.hasText = true;
 
     const versioning = new AuroDependencyVersioning();
 
@@ -132,6 +138,14 @@ export class AuroBadge extends LitElement {
       },
 
       /**
+       * @private
+       */
+      hasText: {
+        type: Boolean,
+        state: true
+      },
+
+      /**
        * Defines the color variant of the badge.
        * @type {'accent1' | 'accent2' | 'accent3' | 'accent4' | 'bronze' | 'cobalt' | 'copper' | 'gold' | 'nickel' | 'platinum' | 'silver' | 'titanium' | 'transparent' | 'info' | 'error' | 'success' | 'warning' | 'emerald' | 'sapphire' | 'ruby' | 'lounge' | 'loungeplus' | 'fare-saver' | 'fare-economy' | 'fare-premium' | 'fare-business' | 'fare-first'}
        */
@@ -178,6 +192,13 @@ export class AuroBadge extends LitElement {
     this.icon = slotContents.some(
       (slotContent) => slotContent.tagName === "AURO-ICON",
     );
+    this.hasText = slotContents.some(
+      (slotContent) =>
+        (slotContent.nodeType === Node.TEXT_NODE &&
+          slotContent.textContent.trim().length > 0) ||
+        (slotContent.nodeType === Node.ELEMENT_NODE &&
+          slotContent.tagName !== "AURO-ICON"),
+    );
   }
 
   connectedCallback() {
@@ -202,6 +223,12 @@ export class AuroBadge extends LitElement {
 
   // function that renders the HTML and CSS into  the scope of the component
   render() {
+    const sizingClassMap = {
+      "body-xs": this.hasText && this.label,
+      "body-default": this.hasText && !this.label,
+      "iconOnly": !this.hasText
+    };
+
     return html`
       ${
         this.target
@@ -218,7 +245,7 @@ export class AuroBadge extends LitElement {
           <${this.iconTag} customColor category="interface" name="x-sm"></${this.iconTag}>
           <span class="util_displayHiddenVisually">Dismiss</span>
         </${this.buttonTag}>`
-          : html`<div class="${this.label ? "body-xs" : ""}">
+          : html`<div class="${classMap(sizingClassMap)}">
           <slot @slotchange="${this.handleContentSlotChanges}"></slot>
         </div>`
       }

--- a/src/auro-badge.js
+++ b/src/auro-badge.js
@@ -183,7 +183,8 @@ export class AuroBadge extends LitElement {
   }
 
   /**
-   * On slot content change, checks for auro-icon and applies attribute to component for adjusted styling.
+   * On slot content change, checks for auro-icon to apply an attribute for adjusted styling, and
+   * computes the `hasText` reactive state that drives text-vs-icon sizing.
    * @private
    * @returns {void}
    */

--- a/src/buttonVersion.js
+++ b/src/buttonVersion.js
@@ -1,1 +1,1 @@
-export default '12.3.0'
+export default "12.3.2";

--- a/src/iconVersion.js
+++ b/src/iconVersion.js
@@ -1,1 +1,1 @@
-export default '9.1.1'
+export default "9.2.0";

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -31,7 +31,12 @@
 :host {
   line-height: 1;
 
+  // Overridable vertical padding hooks. Pill uses a tighter value than the
+  // label/icon variants to offset the body typography line-height so the pill
+  // keeps its previous height. Values are intentional literals (no matching
+  // --ds-size token) but remain themeable via these custom properties.
   --labelpillpadding: .3125rem;
+  --pillpadding: .0625rem;
 }
 
 :host([space]) {
@@ -42,7 +47,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: .688rem var(--ds-size-200, vac.$ds-size-200);
+  // Vertical value is tuned (no matching --ds-size token) to preserve the
+  // badge height against the body-default/body-xs typography line-height.
+  padding: .438rem var(--ds-size-200, vac.$ds-size-200);
   border-width: 1px;
   border-style: solid;
 
@@ -88,7 +95,7 @@
 }
 
 :host([pill]) {
-  padding: var(--labelpillpadding) var(--ds-size-150, vac.$ds-size-150);
+  padding: var(--pillpadding) var(--ds-size-150, vac.$ds-size-150);
   border-radius: 9999px;
   user-select: none;
 }
@@ -105,4 +112,9 @@
 :host([icon][pill]) {
   padding: var(--ds-size-50, vac.$ds-size-50) var(--ds-size-150, vac.$ds-size-150);
   line-height: 0.75rem;
+}
+
+.iconOnly {
+  padding-top: var(--ds-size-50, vac.$ds-size-50);
+  padding-bottom: var(--ds-size-50, vac.$ds-size-50);
 }

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -46,9 +46,9 @@
 :host([target]) {
   [auro-button] {
     &::part(button) {
-      padding: 0;
       min-height: var(--ds-size-500, vac.$ds-size-500);
       max-height: var(--ds-size-500, vac.$ds-size-500);
+      padding: 0;
     }
   }
 }
@@ -57,6 +57,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+
   // Vertical value is tuned (no matching --ds-size token) to preserve the
   // badge height against the body-default/body-xs typography line-height.
   padding: .438rem var(--ds-size-200, vac.$ds-size-200);
@@ -120,4 +121,26 @@
 .iconOnly {
   padding-top: var(--ds-size-50, vac.$ds-size-50);
   padding-bottom: var(--ds-size-50, vac.$ds-size-50);
+}
+
+// Collapse the typography line-height's leading and re-center the text within a
+// box whose height equals the old line-height. Flex centering makes the vertical
+// spacing symmetric regardless of the platform's font metrics, so Chrome for
+// Android no longer pools the leading below the glyph (AB#1547903). The
+// min-height preserves the wrapper's previous height, so no badge padding changes
+// and every variant renders at its existing desktop size.
+.body-default,
+.body-xs {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.body-default {
+  min-height: var(--wcss-body-default-line-height, 1.5rem);
+}
+
+.body-xs {
+  min-height: var(--wcss-body-xs-line-height, 1rem);
 }

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -43,6 +43,16 @@
   margin-left: var(--ds-size-300, vac.$ds-size-300);
 }
 
+:host([target]) {
+  [auro-button] {
+    &::part(button) {
+      padding: 0;
+      min-height: var(--ds-size-500, vac.$ds-size-500);
+      max-height: var(--ds-size-500, vac.$ds-size-500);
+    }
+  }
+}
+
 :host {
   display: inline-flex;
   align-items: center;
@@ -62,13 +72,6 @@
 :host([target]) {
   padding: 0;
   border: 0;
-}
-
-:host([target][ondark][disabled]),
-:host([target][appearance="inverse"][disabled]) {
-  .target {
-    color: var(--ds-color-text-primary-default, vac.$ds-color-text-primary-default);
-  }
 }
 
 .target {

--- a/test/auro-badge.test.js
+++ b/test/auro-badge.test.js
@@ -59,6 +59,22 @@ describe("auro-badge", () => {
     await expect(wrapper.classList.contains("body-xs")).to.be.false;
   });
 
+  it("auro-badge centers its text with a collapsed line-height so mobile spacing stays symmetric", async () => {
+    // Guards AB#1547903: the text wrapper must flex-center its content and
+    // collapse the typography leading (line-height 1 / 16px, not 24px) so Chrome
+    // for Android cannot pool the extra leading below the glyph.
+    const el = await fixture(html`
+      <auro-badge>default</auro-badge>
+    `);
+
+    const wrapper = el.shadowRoot.querySelector("div");
+    const styles = getComputedStyle(wrapper);
+
+    await expect(styles.display).to.equal("flex");
+    await expect(styles.alignItems).to.equal("center");
+    await expect(styles.lineHeight).to.equal("16px");
+  });
+
   it("auro-badge has an action that closes the badge", async () => {
     const el = await fixture(html`
       <auro-badge target>click me</auro-badge>

--- a/test/auro-badge.test.js
+++ b/test/auro-badge.test.js
@@ -27,6 +27,38 @@ describe("auro-badge", () => {
     await expect(button).to.be.null;
   });
 
+  it("auro-badge applies the body-default type class by default", async () => {
+    const el = await fixture(html`
+      <auro-badge>default</auro-badge>
+    `);
+
+    const wrapper = el.shadowRoot.querySelector("div");
+
+    await expect(wrapper.classList.contains("body-default")).to.be.true;
+  });
+
+  it("auro-badge applies the body-xs type class when label", async () => {
+    const el = await fixture(html`
+      <auro-badge label>label</auro-badge>
+    `);
+
+    const wrapper = el.shadowRoot.querySelector("div");
+
+    await expect(wrapper.classList.contains("body-xs")).to.be.true;
+  });
+
+  it("auro-badge applies the iconOnly class and no text type class when only an icon is slotted", async () => {
+    const el = await fixture(html`
+      <auro-badge icon><auro-icon category="interface" name="x-sm"></auro-icon></auro-badge>
+    `);
+
+    const wrapper = el.shadowRoot.querySelector("div");
+
+    await expect(wrapper.classList.contains("iconOnly")).to.be.true;
+    await expect(wrapper.classList.contains("body-default")).to.be.false;
+    await expect(wrapper.classList.contains("body-xs")).to.be.false;
+  });
+
   it("auro-badge has an action that closes the badge", async () => {
     const el = await fixture(html`
       <auro-badge target>click me</auro-badge>

--- a/test/auro-badge.test.js
+++ b/test/auro-badge.test.js
@@ -59,6 +59,36 @@ describe("auro-badge", () => {
     await expect(wrapper.classList.contains("body-xs")).to.be.false;
   });
 
+  it("auro-badge applies a text type class (not iconOnly) when both an icon and text are slotted", async () => {
+    // Guards the mixed-content branch of the hasText slot introspection: a text
+    // node alongside an auro-icon must set hasText true, so the wrapper sizes as
+    // text (body-default) and never collapses to iconOnly.
+    const el = await fixture(html`
+      <auro-badge icon><auro-icon category="interface" name="x-sm"></auro-icon>5</auro-badge>
+    `);
+
+    const wrapper = el.shadowRoot.querySelector("div");
+
+    await expect(wrapper.classList.contains("body-default")).to.be.true;
+    await expect(wrapper.classList.contains("iconOnly")).to.be.false;
+    await expect(wrapper.classList.contains("body-xs")).to.be.false;
+  });
+
+  it("auro-badge gives icon-only badges 4px vertical padding to preserve height (AB#1461919)", async () => {
+    // Guards the intentional .iconOnly padding retune: switching text badges to
+    // typography tokens changed line-height, so icon-only badges get explicit
+    // 4px (--ds-size-50) top/bottom padding to keep their sizing correct.
+    const el = await fixture(html`
+      <auro-badge icon><auro-icon category="interface" name="x-sm"></auro-icon></auro-badge>
+    `);
+
+    const wrapper = el.shadowRoot.querySelector("div");
+    const styles = getComputedStyle(wrapper);
+
+    await expect(styles.paddingTop).to.equal("4px");
+    await expect(styles.paddingBottom).to.equal("4px");
+  });
+
   it("auro-badge centers its text with a collapsed line-height so mobile spacing stays symmetric", async () => {
     // Guards AB#1547903: the text wrapper must flex-center its content and
     // collapse the typography leading (line-height 1 / 16px, not 24px) so Chrome
@@ -83,5 +113,24 @@ describe("auro-badge", () => {
     const root = el.shadowRoot;
     root.getElementById("targetButton").click();
     setTimeout(() => expect(root).to.be.equal(undefined), 3000);
+  });
+
+  it("auro-badge locks the target badge button height to --ds-size-500 (AB#1311533)", async () => {
+    // Guards the :host([target]) ::part(button) sizing rule that matches a target
+    // badge's height (40px / --ds-size-500, padding 0) to a standard badge.
+    const el = await fixture(html`
+      <auro-badge target>close me</auro-badge>
+    `);
+
+    const targetButton = el.shadowRoot.getElementById("targetButton");
+    await targetButton.updateComplete;
+
+    const partButton = targetButton.shadowRoot.querySelector('[part~="button"]');
+    const styles = getComputedStyle(partButton);
+
+    await expect(styles.minHeight).to.equal("40px");
+    await expect(styles.maxHeight).to.equal("40px");
+    await expect(styles.paddingTop).to.equal("0px");
+    await expect(styles.paddingBottom).to.equal("0px");
   });
 });


### PR DESCRIPTION
<!-- auro-pr:pm:start -->
## Post-Mortems

### [AB#1311533](https://itsals.visualstudio.com/5e9f12eb-f830-406f-bee9-be25938f7aaa/_workitems/edit/1311533)

Post-mortem discussion: https://github.com/AlaskaAirlines/auro-badge/discussions/196

A "target" badge is a badge that includes a small dismiss (close) button so a user can remove it. These dismissible badges were rendering at a different size — and, when disabled on dark backgrounds, a different text color — than the standard, non-dismissible badges. That inconsistency made the two kinds of badges look mismatched when placed side by side. This work sizes the dismissible badge to match a standard badge and removes a special color rule that was making disabled dismissible badges look different, so both variants now present consistently.

Ticket: [AB#1311533](https://itsals.visualstudio.com/E_Retain_Content/_workitems/edit/1311533)

### [AB#1461919](https://itsals.visualstudio.com/5e9f12eb-f830-406f-bee9-be25938f7aaa/_workitems/edit/1461919)

Post-mortem discussion: https://github.com/AlaskaAirlines/auro-badge/discussions/195

The auro-badge component was allowing the text inside a badge to be restyled by whatever page it was placed on. When a host page had its own font or text rules, a badge's label could pick up those styles instead of looking the way the design system intends. This work gives every badge its own built-in text style so it always renders consistently, regardless of the surrounding page. Icon-only badges were also given their own sizing so they no longer inherit text spacing meant for words.

Ticket: [AB#1461919](https://itsals.visualstudio.com/E_Retain_Content/_workitems/edit/1461919)

### [AB#1547903](https://itsals.visualstudio.com/5e9f12eb-f830-406f-bee9-be25938f7aaa/_workitems/edit/1547903)

Post-mortem discussion: https://github.com/AlaskaAirlines/auro-badge/discussions/197

On Chrome for Android, a standard text badge showed extra empty space below its text, making it look taller at the bottom than the very same badge on desktop. The two looked mismatched even though nothing about the badge had intentionally changed for mobile. This work removes that uneven gap so a badge has the same balanced spacing on Android as it does on desktop, without altering how any badge looks on desktop.

Ticket: [AB#1547903](https://itsals.visualstudio.com/E_Retain_Content/_workitems/edit/1547903)
<!-- auro-pr:pm:end -->

---

# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-badge/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Align badge sizing, typography, and icon-only behavior for consistent rendering across variants and platforms.

New Features:
- Introduce explicit default and label-specific typography classes for badge text and icon-only variants.

Bug Fixes:
- Make target (dismissible) badges match the height of standard badges and remove inconsistent disabled color overrides.
- Eliminate extra bottom spacing on text badges in Chrome for Android by centering text and collapsing line-height.
- Ensure icon-only badges no longer inherit text-oriented spacing, preserving intended sizing.

Enhancements:
- Refine badge and pill padding tokens to preserve existing visual heights after typography changes.
- Add slot-introspection-based state to distinguish text vs. icon content for more robust sizing logic.

Build:
- Update lit, Auro design-system dependencies, design tokens, and webcore stylesheets to newer versions.

Documentation:
- Add detailed post-mortem documentation for issues [AB#1311533](https://itsals.visualstudio.com/5e9f12eb-f830-406f-bee9-be25938f7aaa/_workitems/edit/1311533), [AB#1461919](https://itsals.visualstudio.com/5e9f12eb-f830-406f-bee9-be25938f7aaa/_workitems/edit/1461919), and [AB#1547903](https://itsals.visualstudio.com/5e9f12eb-f830-406f-bee9-be25938f7aaa/_workitems/edit/1547903) describing root causes, fixes, and learnings.

Tests:
- Extend unit tests to cover new typography classes, icon-only and mixed-content badge sizing, icon-only padding, text centering behavior, and target badge button height.

Chores:
- Update stored version constants for button and icon dependencies to match the new devDependency versions.